### PR TITLE
v1.0.0 - Add lookupRecord & typed DNS lookups ; migrate models to Freezed v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,52 @@
-## 0.3.0
+## 1.0.0
 
-- 
+- Updated `DnsClient` interface:
+    - `lookup` method now supports optional `DnsRecordType` parameter to filter results.
+    - Added `lookupRecord` method to fetch full DNS records with specified type.
+    - Added `close` method with `force` parameter to control client shutdown behavior.
+
+- `DnsOverHttps` implementation:
+    - Refactored `lookup` to support filtering by DNS record type.
+    - Added `lookupRecord` method to perform DNS-over-HTTPS queries returning full `DnsRecord`.
+    - Improved HTTP client initialization and request construction.
+    - Added `close` method override with `force` option.
+
+- `dns_record.dart`:
+    - Migrated to freezed v3 with named parameters, required fields, and improved JSON handling.
+        - Redesigned `DnsRecord`, `Question`, and `Answer` classes with detailed fields and JSON serialization.
+    - Added `DnsRecordType` enum with common DNS record types and utilities.
+    - Added extension on `Answer` to get typed DNS record type.
+    - Improved JSON serialization/deserialization with null safety and type conversions.
+
+- Example usage updated:
+    - Demonstrates querying different DNS record types (A, MX).
+    - Uses enhanced `lookup` and `lookupRecord` methods.
+
+- Tests:
+    - Added comprehensive tests for Google and Cloudflare DoH clients.
+    - Tests cover lookup of A, AAAA, CNAME, MX records.
+    - Added test for client close behavior preventing further lookups.
+
+- Dependency updates:
+    - Dart SDK constraint updated to `>=3.8.0 <4.0.0`.
+    - Updated dependencies:
+        - `http` ^1.6.0
+        - `freezed_annotation` ^3.1.0
+        - `json_annotation` ^4.9.0
+    - Updated dev_dependencies:
+        - `lints` ^5.1.1
+        - `test` ^1.28.0
+        - `json_serializable` ^6.11.3
+        - `build_runner` ^2.10.4
+        - `freezed` ^3.2.4
+
+- Analysis options:
+    - Replaced `pedantic` with `lints/recommended.yaml`.
+    - Added ignore for `invalid_annotation_target` error.
 
 ## 0.2.1
 
-- use `HttpClient` instead of `http` 
+- use `HttpClient` instead of `http`
 
 ## 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Dart implementation of DNS-over-HTTPS.
+Dart implementation of DNS-over-HTTPS client.
 
 [![CodeFactor](https://www.codefactor.io/repository/github/dietfriends/dns_client/badge)](https://www.codefactor.io/repository/github/dietfriends/dns_client)
 [![pub.dev](https://badgen.net/pub/v/dns_client)](https://pub.dev/packages/dns_client)
@@ -13,25 +13,37 @@ import 'package:dns_client/dns_client.dart';
 
 main() async {
   final dns = DnsOverHttps.google();
-  var response = await dns.lookup('google.com');
-  response.forEach((address) {
-    print(address.toString());
-  });}
-```
+  
+  var addressesResponse = await dns.lookup('gmail.com');
+  for (var address in addressesResponse) {
+    print(address);
+  }
 
-```dart
-import 'package:dns_client/dns_client.dart';
-
-main() async {
-  final dns = DnsOverHttps.cloudflare();
-  var response = await dns.lookup('google.com');
-  response.forEach((address) {
-    print(address.toString());
-  });}
+  var mxResponse = await dns.lookup('gmail.com', );
+  for (var mxAddress in mxResponse) {
+    print(mxAddress);
+  }
+}
 ```
 
 ## Features and bugs
 
 Please file feature requests and bugs at the [issue tracker][tracker].
 
-[tracker]: https://github.com/dietfriends/dns_client
+[tracker]: https://github.com/dietfriends/dns_client/issues
+
+
+## Author
+
+- PassionFactory: [dietfriends@GitHub][dietfriends_github] (original author).
+- Graciliano M. Passos: [gmpassos@GitHub][gmpassos_github].
+
+[dietfriends_github]: https://github.com/dietfriends
+[gmpassos_github]: https://github.com/gmpassos
+
+---
+
+## License
+
+This project is licensed under the MIT License – see the [LICENSE](LICENSE) file for details.
+

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,14 +1,32 @@
-# Defines a default set of lint rules enforced for
-# projects at Google. For details and rationale,
-# see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
 
-# For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
-# Uncomment to specify additional rules.
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
 # linter:
 #   rules:
 #     - camel_case_types
 
 analyzer:
+  errors:
+    invalid_annotation_target: ignore
 #   exclude:
 #     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/dns_client.iml
+++ b/dns_client.iml
@@ -1,21 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="JAVA_MODULE" version="4">
-  <component name="FacetManager">
-    <facet type="android" name="Android">
-      <configuration />
-    </facet>
-  </component>
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
-      <excludeFolder url="file://$MODULE_DIR$/example_flutter/.dart_tool" />
-      <excludeFolder url="file://$MODULE_DIR$/example_flutter/build" />
-      <excludeFolder url="file://$MODULE_DIR$/example_flutter/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
-    <orderEntry type="jdk" jdkName="Android API 29 Platform" jdkType="Android SDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
     <orderEntry type="library" name="Dart Packages" level="project" />

--- a/example/dns_client_example.dart
+++ b/example/dns_client_example.dart
@@ -1,9 +1,34 @@
 import 'package:dns_client/dns_client.dart';
 
-void main() async {
+main() async {
   final dns = DnsOverHttps.google();
-  final response = await dns.lookup('google.com');
-  response.forEach((address) {
-    print(address.toString());
-  });
+
+  var addressesResponse = await dns.lookup('gmail.com');
+
+  print('Addresses:');
+  for (var address in addressesResponse) {
+    print('-- $address');
+  }
+
+  var mxResponse = await dns.lookup('gmail.com', type: DnsRecordType.MX);
+  print('MX addresses:');
+  for (var mxAddress in mxResponse) {
+    print('-- $mxAddress');
+  }
 }
+
+/*
+/////////////
+// OUTPUT: //
+/////////////
+
+Addresses:
+-- InternetAddress('172.217.29.229', IPv4)
+-- InternetAddress('2800:3f0:4001:839::2005', IPv6)
+MX addresses:
+-- InternetAddress('2a00:1450:4025:402::1b', IPv6)
+-- InternetAddress('2a00:1450:400c:c00::1a', IPv6)
+-- InternetAddress('2a00:1450:4013:c1e::1b', IPv6)
+-- InternetAddress('2a00:1450:4009:c0f::1a', IPv6)
+-- InternetAddress('2800:3f0:4003:c0f::1a', IPv6)
+*/

--- a/lib/dns_client.dart
+++ b/lib/dns_client.dart
@@ -1,4 +1,5 @@
-library dns_client;
+/// DNS Client Library.
+library;
 
 export 'src/dns_client.dart';
 export 'src/dns_over_https.dart';

--- a/lib/src/dns_client.dart
+++ b/lib/src/dns_client.dart
@@ -1,5 +1,43 @@
 import 'dart:io';
 
+import 'dns_record.dart';
+
+export 'dns_record.dart';
+
+/// Abstract DNS client that can resolve hostnames and fetch DNS records.
 abstract class DnsClient {
-  Future<List<InternetAddress>> lookup(String hostname);
+  /// Resolves the given [hostname] to a list of [InternetAddress].
+  ///
+  /// If [type] is provided, only records of that type are returned (e.g., [DnsRecordType.MX]).
+  /// If [type] is null, only [DnsRecordType.A] (IPv4) and [DnsRecordType.AAAA] (IPv6)
+  /// records are returned by default, filtering the answers from a broader [DnsRecordType.ANY] query.
+  ///
+  /// **Note:** Not all DNS providers support `ANY` queries, and some may return incomplete
+  /// results or block them entirely. This method filters the answers to include only A and AAAA
+  /// records regardless of provider behavior.
+  ///
+  /// Uses [lookupRecord] internally to fetch the full DNS response and filters the answers
+  /// according to the requested type.
+  ///
+  /// Returns a [List] of [InternetAddress] objects corresponding to the filtered records.
+  Future<List<InternetAddress>> lookup(String hostname, {DnsRecordType? type});
+
+  /// Looks up a DNS record of the specified [type] for the given [hostname].
+  ///
+  /// By default, [DnsRecordType.ANY] is used to fetch all available records.
+  /// Returns a [DnsRecord] containing the answers and metadata.
+  Future<DnsRecord> lookupRecord(
+    String hostname, {
+    DnsRecordType type = DnsRecordType.ANY,
+  });
+
+  /// Closes the DNS client and releases any underlying resources.
+  ///
+  /// If [force] is `false` (the default), the client will allow
+  /// active connections to finish before closing.
+  /// If [force] is `true`, all active connections are immediately
+  /// terminated, and further lookups will throw a [StateError].
+  ///
+  /// After calling this method, the client **cannot be used** again.
+  void close({bool force = false});
 }

--- a/lib/src/dns_record.dart
+++ b/lib/src/dns_record.dart
@@ -1,46 +1,151 @@
+// ignore_for_file: constant_identifier_names, non_constant_identifier_names
+
+import 'dart:async';
+import 'dart:io';
+
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+part 'dns_record.freezed.dart';
 part 'dns_record.g.dart';
 
-part 'dns_record.freezed.dart';
-
+/// Represents a DNS response record returned by a server.
 @freezed
-class DnsRecord with _$DnsRecord {
-  const DnsRecord._(); // Added constructor
-  const factory DnsRecord(
-      @JsonKey(name: 'Status') int status,
-      bool TC,
-      bool RD,
-      bool RA,
-      bool AD,
-      bool CD,
-      @JsonKey(name: 'edns_client_subnet') String? ednsClientSubnet,
-      @JsonKey(name: 'Answer') List<Answer>? answer,
-      @JsonKey(name: 'Comment') String? comment) = _DnsRecord;
+abstract class DnsRecord with _$DnsRecord {
+  const DnsRecord._();
 
-  factory DnsRecord.fromJson(Map<String, dynamic> json) => _$DnsRecordFromJson(json);
+  /// Creates a DNS record from the JSON response.
+  ///
+  /// Fields correspond to the standard DNS over HTTPS (DoH) JSON format.
+  const factory DnsRecord({
+    /// DNS response code (e.g., 1 = NOERROR, 2 = SERVFAIL)
+    @JsonKey(name: 'Status') required int status,
 
-  // SERVFAIL - Standard DNS response code (32 bit integer).
+    /// Truncated flag – true if the response was too large for a UDP packet
+    required bool TC,
+
+    /// Recursion desired – true if the client requested recursive resolution
+    required bool RD,
+
+    /// Recursion available – true if the server supports recursion
+    required bool RA,
+
+    /// Authenticated data – true if DNSSEC validation passed
+    required bool AD,
+
+    /// Checking disabled – true if DNSSEC checks were disabled by the client
+    required bool CD,
+
+    /// Client subnet information (EDNS)
+    @JsonKey(name: 'edns_client_subnet') String? ednsClientSubnet,
+
+    /// List of DNS answers returned
+    @JsonKey(name: 'Answer') List<Answer>? answer,
+
+    /// Optional comment or metadata
+    @JsonKey(name: 'Comment') String? comment,
+  }) = _DnsRecord;
+
+  /// Creates a [DnsRecord] from a JSON map.
+  factory DnsRecord.fromJson(Map<String, dynamic> json) =>
+      _$DnsRecordFromJson(json);
+
+  /// Returns true if the response code is SERVFAIL.
   bool get isFailure => status == 2;
 
-  // NOERROR - Standard DNS response code (32 bit integer)
+  /// Returns true if the response code is NOERROR.
   bool get isSuccess => status == 1;
 }
 
+/// Represents a DNS question in a query.
 @freezed
-class Question with _$Question {
+abstract class Question with _$Question {
+  /// Creates a DNS question with [name] and [type].
   const factory Question(String name, int type) = _Question;
 
-  factory Question.fromJson(Map<String, dynamic> json) => _$QuestionFromJson(json);
+  /// Creates a [Question] from a JSON map.
+  factory Question.fromJson(Map<String, dynamic> json) =>
+      _$QuestionFromJson(json);
 }
 
+/// Represents a DNS answer returned in a response.
 @freezed
-class Answer with _$Answer {
-  const factory Answer(String name, int type, int TTL, String data) = _Answer;
+abstract class Answer with _$Answer {
+  /// Creates a DNS answer with optional fields depending on the record type.
+  const factory Answer(
+    /// Name of the resource record
+    String name,
 
+    /// Numeric type code of the DNS record
+    int type,
+
+    /// Time to live (TTL) in seconds
+    int TTL,
+
+    /// Data contained in the record (IP, CNAME, TXT, etc.)
+    String data,
+  ) = _Answer;
+
+  /// Creates an [Answer] from a JSON map.
   factory Answer.fromJson(Map<String, dynamic> json) => _$AnswerFromJson(json);
+}
 
-  static List<Answer> listFromJson(List<Map<String, dynamic>> input) {
-    return input.map((i) => _Answer.fromJson(i)).toList();
+extension DnsAnswerExtension on Answer {
+  /// Converts the numeric DNS type code to the enum
+  DnsRecordType get recordType => DnsRecordType.fromInt(type);
+
+  FutureOr<InternetAddress> get asInternetAddress {
+    var d = data.trim();
+    var parts = d.split(RegExp(r'\s+'));
+
+    var a = parts.last;
+    while (a.startsWith('.')) {
+      a = a.substring(1);
+    }
+    while (a.endsWith('.')) {
+      a = a.substring(0, a.length - 1);
+    }
+
+    if (a.isEmpty) {
+      throw StateError("Empty address!");
+    }
+
+    return InternetAddress.tryParse(a) ??
+        InternetAddress.lookup(a).then((l) => l.first);
+  }
+
+  Future<InternetAddress> get asInternetAddressAsync {
+    var a = asInternetAddress;
+    return a is Future<InternetAddress> ? a : Future.value(a);
+  }
+}
+
+/// Represents the type of a DNS record.
+///
+/// Each type has a numeric code (`typeValue`), a string label (`value`),
+/// and a human-readable description (`description`).
+enum DnsRecordType {
+  A(1, 'A', 'IPv4 address record'),
+  AAAA(28, 'AAAA', 'IPv6 address record'),
+  MX(15, 'MX', 'Mail exchange record'),
+  CNAME(5, 'CNAME', 'Canonical name (alias) record'),
+  TXT(16, 'TXT', 'Text record, often for SPF/DKIM/etc.'),
+  NS(2, 'NS', 'Authoritative name server record'),
+  SOA(6, 'SOA', 'Start of authority record'),
+  HTTPS(65, 'HTTPS', 'HTTPS service binding record (SVCB)'),
+  CAA(257, 'CAA', 'Certificate Authority Authorization record'),
+  ANY(255, 'ANY', 'Wildcard type to query all records');
+
+  final int typeValue;
+  final String value;
+  final String description;
+
+  const DnsRecordType(this.typeValue, this.value, this.description);
+
+  /// Get enum from numeric DNS type code
+  static DnsRecordType fromInt(int type) {
+    for (var recordType in DnsRecordType.values) {
+      if (recordType.typeValue == type) return recordType;
+    }
+    throw ArgumentError('Unknown DNS record type: $type');
   }
 }

--- a/lib/src/dns_record.freezed.dart
+++ b/lib/src/dns_record.freezed.dart
@@ -1,6 +1,7 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 part of 'dns_record.dart';
 
@@ -8,696 +9,866 @@ part of 'dns_record.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
-
-DnsRecord _$DnsRecordFromJson(Map<String, dynamic> json) {
-  return _DnsRecord.fromJson(json);
-}
-
-/// @nodoc
-class _$DnsRecordTearOff {
-  const _$DnsRecordTearOff();
-
-  _DnsRecord call(
-      @JsonKey(name: 'Status') int status,
-      bool TC,
-      bool RD,
-      bool RA,
-      bool AD,
-      bool CD,
-      @JsonKey(name: 'edns_client_subnet') String? ednsClientSubnet,
-      @JsonKey(name: 'Answer') List<Answer>? answer,
-      @JsonKey(name: 'Comment') String? comment) {
-    return _DnsRecord(
-      status,
-      TC,
-      RD,
-      RA,
-      AD,
-      CD,
-      ednsClientSubnet,
-      answer,
-      comment,
-    );
-  }
-
-  DnsRecord fromJson(Map<String, Object?> json) {
-    return DnsRecord.fromJson(json);
-  }
-}
-
-/// @nodoc
-const $DnsRecord = _$DnsRecordTearOff();
 
 /// @nodoc
 mixin _$DnsRecord {
-  @JsonKey(name: 'Status')
-  int get status => throw _privateConstructorUsedError;
-  bool get TC => throw _privateConstructorUsedError;
-  bool get RD => throw _privateConstructorUsedError;
-  bool get RA => throw _privateConstructorUsedError;
-  bool get AD => throw _privateConstructorUsedError;
-  bool get CD => throw _privateConstructorUsedError;
-  @JsonKey(name: 'edns_client_subnet')
-  String? get ednsClientSubnet => throw _privateConstructorUsedError;
-  @JsonKey(name: 'Answer')
-  List<Answer>? get answer => throw _privateConstructorUsedError;
-  @JsonKey(name: 'Comment')
-  String? get comment => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $DnsRecordCopyWith<DnsRecord> get copyWith =>
-      throw _privateConstructorUsedError;
+/// DNS response code (e.g., 1 = NOERROR, 2 = SERVFAIL)
+@JsonKey(name: 'Status') int get status;/// Truncated flag – true if the response was too large for a UDP packet
+ bool get TC;/// Recursion desired – true if the client requested recursive resolution
+ bool get RD;/// Recursion available – true if the server supports recursion
+ bool get RA;/// Authenticated data – true if DNSSEC validation passed
+ bool get AD;/// Checking disabled – true if DNSSEC checks were disabled by the client
+ bool get CD;/// Client subnet information (EDNS)
+@JsonKey(name: 'edns_client_subnet') String? get ednsClientSubnet;/// List of DNS answers returned
+@JsonKey(name: 'Answer') List<Answer>? get answer;/// Optional comment or metadata
+@JsonKey(name: 'Comment') String? get comment;
+/// Create a copy of DnsRecord
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$DnsRecordCopyWith<DnsRecord> get copyWith => _$DnsRecordCopyWithImpl<DnsRecord>(this as DnsRecord, _$identity);
+
+  /// Serializes this DnsRecord to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DnsRecord&&(identical(other.status, status) || other.status == status)&&(identical(other.TC, TC) || other.TC == TC)&&(identical(other.RD, RD) || other.RD == RD)&&(identical(other.RA, RA) || other.RA == RA)&&(identical(other.AD, AD) || other.AD == AD)&&(identical(other.CD, CD) || other.CD == CD)&&(identical(other.ednsClientSubnet, ednsClientSubnet) || other.ednsClientSubnet == ednsClientSubnet)&&const DeepCollectionEquality().equals(other.answer, answer)&&(identical(other.comment, comment) || other.comment == comment));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status,TC,RD,RA,AD,CD,ednsClientSubnet,const DeepCollectionEquality().hash(answer),comment);
+
+@override
+String toString() {
+  return 'DnsRecord(status: $status, TC: $TC, RD: $RD, RA: $RA, AD: $AD, CD: $CD, ednsClientSubnet: $ednsClientSubnet, answer: $answer, comment: $comment)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $DnsRecordCopyWith<$Res> {
-  factory $DnsRecordCopyWith(DnsRecord value, $Res Function(DnsRecord) then) =
-      _$DnsRecordCopyWithImpl<$Res>;
-  $Res call(
-      {@JsonKey(name: 'Status') int status,
-      bool TC,
-      bool RD,
-      bool RA,
-      bool AD,
-      bool CD,
-      @JsonKey(name: 'edns_client_subnet') String? ednsClientSubnet,
-      @JsonKey(name: 'Answer') List<Answer>? answer,
-      @JsonKey(name: 'Comment') String? comment});
+abstract mixin class $DnsRecordCopyWith<$Res>  {
+  factory $DnsRecordCopyWith(DnsRecord value, $Res Function(DnsRecord) _then) = _$DnsRecordCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'Status') int status, bool TC, bool RD, bool RA, bool AD, bool CD,@JsonKey(name: 'edns_client_subnet') String? ednsClientSubnet,@JsonKey(name: 'Answer') List<Answer>? answer,@JsonKey(name: 'Comment') String? comment
+});
+
+
+
+
 }
-
 /// @nodoc
-class _$DnsRecordCopyWithImpl<$Res> implements $DnsRecordCopyWith<$Res> {
-  _$DnsRecordCopyWithImpl(this._value, this._then);
+class _$DnsRecordCopyWithImpl<$Res>
+    implements $DnsRecordCopyWith<$Res> {
+  _$DnsRecordCopyWithImpl(this._self, this._then);
 
-  final DnsRecord _value;
-  // ignore: unused_field
+  final DnsRecord _self;
   final $Res Function(DnsRecord) _then;
 
-  @override
-  $Res call({
-    Object? status = freezed,
-    Object? TC = freezed,
-    Object? RD = freezed,
-    Object? RA = freezed,
-    Object? AD = freezed,
-    Object? CD = freezed,
-    Object? ednsClientSubnet = freezed,
-    Object? answer = freezed,
-    Object? comment = freezed,
-  }) {
-    return _then(_value.copyWith(
-      status: status == freezed
-          ? _value.status
-          : status // ignore: cast_nullable_to_non_nullable
-              as int,
-      TC: TC == freezed
-          ? _value.TC
-          : TC // ignore: cast_nullable_to_non_nullable
-              as bool,
-      RD: RD == freezed
-          ? _value.RD
-          : RD // ignore: cast_nullable_to_non_nullable
-              as bool,
-      RA: RA == freezed
-          ? _value.RA
-          : RA // ignore: cast_nullable_to_non_nullable
-              as bool,
-      AD: AD == freezed
-          ? _value.AD
-          : AD // ignore: cast_nullable_to_non_nullable
-              as bool,
-      CD: CD == freezed
-          ? _value.CD
-          : CD // ignore: cast_nullable_to_non_nullable
-              as bool,
-      ednsClientSubnet: ednsClientSubnet == freezed
-          ? _value.ednsClientSubnet
-          : ednsClientSubnet // ignore: cast_nullable_to_non_nullable
-              as String?,
-      answer: answer == freezed
-          ? _value.answer
-          : answer // ignore: cast_nullable_to_non_nullable
-              as List<Answer>?,
-      comment: comment == freezed
-          ? _value.comment
-          : comment // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Create a copy of DnsRecord
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? status = null,Object? TC = null,Object? RD = null,Object? RA = null,Object? AD = null,Object? CD = null,Object? ednsClientSubnet = freezed,Object? answer = freezed,Object? comment = freezed,}) {
+  return _then(_self.copyWith(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as int,TC: null == TC ? _self.TC : TC // ignore: cast_nullable_to_non_nullable
+as bool,RD: null == RD ? _self.RD : RD // ignore: cast_nullable_to_non_nullable
+as bool,RA: null == RA ? _self.RA : RA // ignore: cast_nullable_to_non_nullable
+as bool,AD: null == AD ? _self.AD : AD // ignore: cast_nullable_to_non_nullable
+as bool,CD: null == CD ? _self.CD : CD // ignore: cast_nullable_to_non_nullable
+as bool,ednsClientSubnet: freezed == ednsClientSubnet ? _self.ednsClientSubnet : ednsClientSubnet // ignore: cast_nullable_to_non_nullable
+as String?,answer: freezed == answer ? _self.answer : answer // ignore: cast_nullable_to_non_nullable
+as List<Answer>?,comment: freezed == comment ? _self.comment : comment // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
 }
 
-/// @nodoc
-abstract class _$DnsRecordCopyWith<$Res> implements $DnsRecordCopyWith<$Res> {
-  factory _$DnsRecordCopyWith(
-          _DnsRecord value, $Res Function(_DnsRecord) then) =
-      __$DnsRecordCopyWithImpl<$Res>;
-  @override
-  $Res call(
-      {@JsonKey(name: 'Status') int status,
-      bool TC,
-      bool RD,
-      bool RA,
-      bool AD,
-      bool CD,
-      @JsonKey(name: 'edns_client_subnet') String? ednsClientSubnet,
-      @JsonKey(name: 'Answer') List<Answer>? answer,
-      @JsonKey(name: 'Comment') String? comment});
 }
 
-/// @nodoc
-class __$DnsRecordCopyWithImpl<$Res> extends _$DnsRecordCopyWithImpl<$Res>
-    implements _$DnsRecordCopyWith<$Res> {
-  __$DnsRecordCopyWithImpl(_DnsRecord _value, $Res Function(_DnsRecord) _then)
-      : super(_value, (v) => _then(v as _DnsRecord));
 
-  @override
-  _DnsRecord get _value => super._value as _DnsRecord;
+/// Adds pattern-matching-related methods to [DnsRecord].
+extension DnsRecordPatterns on DnsRecord {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @override
-  $Res call({
-    Object? status = freezed,
-    Object? TC = freezed,
-    Object? RD = freezed,
-    Object? RA = freezed,
-    Object? AD = freezed,
-    Object? CD = freezed,
-    Object? ednsClientSubnet = freezed,
-    Object? answer = freezed,
-    Object? comment = freezed,
-  }) {
-    return _then(_DnsRecord(
-      status == freezed
-          ? _value.status
-          : status // ignore: cast_nullable_to_non_nullable
-              as int,
-      TC == freezed
-          ? _value.TC
-          : TC // ignore: cast_nullable_to_non_nullable
-              as bool,
-      RD == freezed
-          ? _value.RD
-          : RD // ignore: cast_nullable_to_non_nullable
-              as bool,
-      RA == freezed
-          ? _value.RA
-          : RA // ignore: cast_nullable_to_non_nullable
-              as bool,
-      AD == freezed
-          ? _value.AD
-          : AD // ignore: cast_nullable_to_non_nullable
-              as bool,
-      CD == freezed
-          ? _value.CD
-          : CD // ignore: cast_nullable_to_non_nullable
-              as bool,
-      ednsClientSubnet == freezed
-          ? _value.ednsClientSubnet
-          : ednsClientSubnet // ignore: cast_nullable_to_non_nullable
-              as String?,
-      answer == freezed
-          ? _value.answer
-          : answer // ignore: cast_nullable_to_non_nullable
-              as List<Answer>?,
-      comment == freezed
-          ? _value.comment
-          : comment // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _DnsRecord value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _DnsRecord() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _DnsRecord value)  $default,){
+final _that = this;
+switch (_that) {
+case _DnsRecord():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _DnsRecord value)?  $default,){
+final _that = this;
+switch (_that) {
+case _DnsRecord() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'Status')  int status,  bool TC,  bool RD,  bool RA,  bool AD,  bool CD, @JsonKey(name: 'edns_client_subnet')  String? ednsClientSubnet, @JsonKey(name: 'Answer')  List<Answer>? answer, @JsonKey(name: 'Comment')  String? comment)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _DnsRecord() when $default != null:
+return $default(_that.status,_that.TC,_that.RD,_that.RA,_that.AD,_that.CD,_that.ednsClientSubnet,_that.answer,_that.comment);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'Status')  int status,  bool TC,  bool RD,  bool RA,  bool AD,  bool CD, @JsonKey(name: 'edns_client_subnet')  String? ednsClientSubnet, @JsonKey(name: 'Answer')  List<Answer>? answer, @JsonKey(name: 'Comment')  String? comment)  $default,) {final _that = this;
+switch (_that) {
+case _DnsRecord():
+return $default(_that.status,_that.TC,_that.RD,_that.RA,_that.AD,_that.CD,_that.ednsClientSubnet,_that.answer,_that.comment);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'Status')  int status,  bool TC,  bool RD,  bool RA,  bool AD,  bool CD, @JsonKey(name: 'edns_client_subnet')  String? ednsClientSubnet, @JsonKey(name: 'Answer')  List<Answer>? answer, @JsonKey(name: 'Comment')  String? comment)?  $default,) {final _that = this;
+switch (_that) {
+case _DnsRecord() when $default != null:
+return $default(_that.status,_that.TC,_that.RD,_that.RA,_that.AD,_that.CD,_that.ednsClientSubnet,_that.answer,_that.comment);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$_DnsRecord extends _DnsRecord {
-  const _$_DnsRecord(
-      @JsonKey(name: 'Status') this.status,
-      this.TC,
-      this.RD,
-      this.RA,
-      this.AD,
-      this.CD,
-      @JsonKey(name: 'edns_client_subnet') this.ednsClientSubnet,
-      @JsonKey(name: 'Answer') this.answer,
-      @JsonKey(name: 'Comment') this.comment)
-      : super._();
 
-  factory _$_DnsRecord.fromJson(Map<String, dynamic> json) =>
-      _$$_DnsRecordFromJson(json);
+class _DnsRecord extends DnsRecord {
+  const _DnsRecord({@JsonKey(name: 'Status') required this.status, required this.TC, required this.RD, required this.RA, required this.AD, required this.CD, @JsonKey(name: 'edns_client_subnet') this.ednsClientSubnet, @JsonKey(name: 'Answer') final  List<Answer>? answer, @JsonKey(name: 'Comment') this.comment}): _answer = answer,super._();
+  factory _DnsRecord.fromJson(Map<String, dynamic> json) => _$DnsRecordFromJson(json);
 
-  @override
-  @JsonKey(name: 'Status')
-  final int status;
-  @override
-  final bool TC;
-  @override
-  final bool RD;
-  @override
-  final bool RA;
-  @override
-  final bool AD;
-  @override
-  final bool CD;
-  @override
-  @JsonKey(name: 'edns_client_subnet')
-  final String? ednsClientSubnet;
-  @override
-  @JsonKey(name: 'Answer')
-  final List<Answer>? answer;
-  @override
-  @JsonKey(name: 'Comment')
-  final String? comment;
-
-  @override
-  String toString() {
-    return 'DnsRecord(status: $status, TC: $TC, RD: $RD, RA: $RA, AD: $AD, CD: $CD, ednsClientSubnet: $ednsClientSubnet, answer: $answer, comment: $comment)';
-  }
-
-  @override
-  bool operator ==(dynamic other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _DnsRecord &&
-            (identical(other.status, status) || other.status == status) &&
-            (identical(other.TC, TC) || other.TC == TC) &&
-            (identical(other.RD, RD) || other.RD == RD) &&
-            (identical(other.RA, RA) || other.RA == RA) &&
-            (identical(other.AD, AD) || other.AD == AD) &&
-            (identical(other.CD, CD) || other.CD == CD) &&
-            (identical(other.ednsClientSubnet, ednsClientSubnet) ||
-                other.ednsClientSubnet == ednsClientSubnet) &&
-            const DeepCollectionEquality().equals(other.answer, answer) &&
-            (identical(other.comment, comment) || other.comment == comment));
-  }
-
-  @override
-  int get hashCode => Object.hash(runtimeType, status, TC, RD, RA, AD, CD,
-      ednsClientSubnet, const DeepCollectionEquality().hash(answer), comment);
-
-  @JsonKey(ignore: true)
-  @override
-  _$DnsRecordCopyWith<_DnsRecord> get copyWith =>
-      __$DnsRecordCopyWithImpl<_DnsRecord>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$_DnsRecordToJson(this);
-  }
+/// DNS response code (e.g., 1 = NOERROR, 2 = SERVFAIL)
+@override@JsonKey(name: 'Status') final  int status;
+/// Truncated flag – true if the response was too large for a UDP packet
+@override final  bool TC;
+/// Recursion desired – true if the client requested recursive resolution
+@override final  bool RD;
+/// Recursion available – true if the server supports recursion
+@override final  bool RA;
+/// Authenticated data – true if DNSSEC validation passed
+@override final  bool AD;
+/// Checking disabled – true if DNSSEC checks were disabled by the client
+@override final  bool CD;
+/// Client subnet information (EDNS)
+@override@JsonKey(name: 'edns_client_subnet') final  String? ednsClientSubnet;
+/// List of DNS answers returned
+ final  List<Answer>? _answer;
+/// List of DNS answers returned
+@override@JsonKey(name: 'Answer') List<Answer>? get answer {
+  final value = _answer;
+  if (value == null) return null;
+  if (_answer is EqualUnmodifiableListView) return _answer;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
 }
 
-abstract class _DnsRecord extends DnsRecord {
-  const factory _DnsRecord(
-      @JsonKey(name: 'Status') int status,
-      bool TC,
-      bool RD,
-      bool RA,
-      bool AD,
-      bool CD,
-      @JsonKey(name: 'edns_client_subnet') String? ednsClientSubnet,
-      @JsonKey(name: 'Answer') List<Answer>? answer,
-      @JsonKey(name: 'Comment') String? comment) = _$_DnsRecord;
-  const _DnsRecord._() : super._();
+/// Optional comment or metadata
+@override@JsonKey(name: 'Comment') final  String? comment;
 
-  factory _DnsRecord.fromJson(Map<String, dynamic> json) =
-      _$_DnsRecord.fromJson;
+/// Create a copy of DnsRecord
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$DnsRecordCopyWith<_DnsRecord> get copyWith => __$DnsRecordCopyWithImpl<_DnsRecord>(this, _$identity);
 
-  @override
-  @JsonKey(name: 'Status')
-  int get status;
-  @override
-  bool get TC;
-  @override
-  bool get RD;
-  @override
-  bool get RA;
-  @override
-  bool get AD;
-  @override
-  bool get CD;
-  @override
-  @JsonKey(name: 'edns_client_subnet')
-  String? get ednsClientSubnet;
-  @override
-  @JsonKey(name: 'Answer')
-  List<Answer>? get answer;
-  @override
-  @JsonKey(name: 'Comment')
-  String? get comment;
-  @override
-  @JsonKey(ignore: true)
-  _$DnsRecordCopyWith<_DnsRecord> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+Map<String, dynamic> toJson() {
+  return _$DnsRecordToJson(this, );
 }
 
-Question _$QuestionFromJson(Map<String, dynamic> json) {
-  return _Question.fromJson(json);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _DnsRecord&&(identical(other.status, status) || other.status == status)&&(identical(other.TC, TC) || other.TC == TC)&&(identical(other.RD, RD) || other.RD == RD)&&(identical(other.RA, RA) || other.RA == RA)&&(identical(other.AD, AD) || other.AD == AD)&&(identical(other.CD, CD) || other.CD == CD)&&(identical(other.ednsClientSubnet, ednsClientSubnet) || other.ednsClientSubnet == ednsClientSubnet)&&const DeepCollectionEquality().equals(other._answer, _answer)&&(identical(other.comment, comment) || other.comment == comment));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,status,TC,RD,RA,AD,CD,ednsClientSubnet,const DeepCollectionEquality().hash(_answer),comment);
+
+@override
+String toString() {
+  return 'DnsRecord(status: $status, TC: $TC, RD: $RD, RA: $RA, AD: $AD, CD: $CD, ednsClientSubnet: $ednsClientSubnet, answer: $answer, comment: $comment)';
+}
+
+
 }
 
 /// @nodoc
-class _$QuestionTearOff {
-  const _$QuestionTearOff();
+abstract mixin class _$DnsRecordCopyWith<$Res> implements $DnsRecordCopyWith<$Res> {
+  factory _$DnsRecordCopyWith(_DnsRecord value, $Res Function(_DnsRecord) _then) = __$DnsRecordCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'Status') int status, bool TC, bool RD, bool RA, bool AD, bool CD,@JsonKey(name: 'edns_client_subnet') String? ednsClientSubnet,@JsonKey(name: 'Answer') List<Answer>? answer,@JsonKey(name: 'Comment') String? comment
+});
 
-  _Question call(String name, int type) {
-    return _Question(
-      name,
-      type,
-    );
-  }
 
-  Question fromJson(Map<String, Object?> json) {
-    return Question.fromJson(json);
-  }
+
+
+}
+/// @nodoc
+class __$DnsRecordCopyWithImpl<$Res>
+    implements _$DnsRecordCopyWith<$Res> {
+  __$DnsRecordCopyWithImpl(this._self, this._then);
+
+  final _DnsRecord _self;
+  final $Res Function(_DnsRecord) _then;
+
+/// Create a copy of DnsRecord
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? status = null,Object? TC = null,Object? RD = null,Object? RA = null,Object? AD = null,Object? CD = null,Object? ednsClientSubnet = freezed,Object? answer = freezed,Object? comment = freezed,}) {
+  return _then(_DnsRecord(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as int,TC: null == TC ? _self.TC : TC // ignore: cast_nullable_to_non_nullable
+as bool,RD: null == RD ? _self.RD : RD // ignore: cast_nullable_to_non_nullable
+as bool,RA: null == RA ? _self.RA : RA // ignore: cast_nullable_to_non_nullable
+as bool,AD: null == AD ? _self.AD : AD // ignore: cast_nullable_to_non_nullable
+as bool,CD: null == CD ? _self.CD : CD // ignore: cast_nullable_to_non_nullable
+as bool,ednsClientSubnet: freezed == ednsClientSubnet ? _self.ednsClientSubnet : ednsClientSubnet // ignore: cast_nullable_to_non_nullable
+as String?,answer: freezed == answer ? _self._answer : answer // ignore: cast_nullable_to_non_nullable
+as List<Answer>?,comment: freezed == comment ? _self.comment : comment // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
 }
 
-/// @nodoc
-const $Question = _$QuestionTearOff();
+
+}
+
 
 /// @nodoc
 mixin _$Question {
-  String get name => throw _privateConstructorUsedError;
-  int get type => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $QuestionCopyWith<Question> get copyWith =>
-      throw _privateConstructorUsedError;
+ String get name; int get type;
+/// Create a copy of Question
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$QuestionCopyWith<Question> get copyWith => _$QuestionCopyWithImpl<Question>(this as Question, _$identity);
+
+  /// Serializes this Question to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Question&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,type);
+
+@override
+String toString() {
+  return 'Question(name: $name, type: $type)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $QuestionCopyWith<$Res> {
-  factory $QuestionCopyWith(Question value, $Res Function(Question) then) =
-      _$QuestionCopyWithImpl<$Res>;
-  $Res call({String name, int type});
+abstract mixin class $QuestionCopyWith<$Res>  {
+  factory $QuestionCopyWith(Question value, $Res Function(Question) _then) = _$QuestionCopyWithImpl;
+@useResult
+$Res call({
+ String name, int type
+});
+
+
+
+
 }
-
 /// @nodoc
-class _$QuestionCopyWithImpl<$Res> implements $QuestionCopyWith<$Res> {
-  _$QuestionCopyWithImpl(this._value, this._then);
+class _$QuestionCopyWithImpl<$Res>
+    implements $QuestionCopyWith<$Res> {
+  _$QuestionCopyWithImpl(this._self, this._then);
 
-  final Question _value;
-  // ignore: unused_field
+  final Question _self;
   final $Res Function(Question) _then;
 
-  @override
-  $Res call({
-    Object? name = freezed,
-    Object? type = freezed,
-  }) {
-    return _then(_value.copyWith(
-      name: name == freezed
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      type: type == freezed
-          ? _value.type
-          : type // ignore: cast_nullable_to_non_nullable
-              as int,
-    ));
-  }
+/// Create a copy of Question
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? type = null,}) {
+  return _then(_self.copyWith(
+name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
 }
 
-/// @nodoc
-abstract class _$QuestionCopyWith<$Res> implements $QuestionCopyWith<$Res> {
-  factory _$QuestionCopyWith(_Question value, $Res Function(_Question) then) =
-      __$QuestionCopyWithImpl<$Res>;
-  @override
-  $Res call({String name, int type});
 }
 
-/// @nodoc
-class __$QuestionCopyWithImpl<$Res> extends _$QuestionCopyWithImpl<$Res>
-    implements _$QuestionCopyWith<$Res> {
-  __$QuestionCopyWithImpl(_Question _value, $Res Function(_Question) _then)
-      : super(_value, (v) => _then(v as _Question));
 
-  @override
-  _Question get _value => super._value as _Question;
+/// Adds pattern-matching-related methods to [Question].
+extension QuestionPatterns on Question {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @override
-  $Res call({
-    Object? name = freezed,
-    Object? type = freezed,
-  }) {
-    return _then(_Question(
-      name == freezed
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      type == freezed
-          ? _value.type
-          : type // ignore: cast_nullable_to_non_nullable
-              as int,
-    ));
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Question value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Question() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Question value)  $default,){
+final _that = this;
+switch (_that) {
+case _Question():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Question value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Question() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String name,  int type)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Question() when $default != null:
+return $default(_that.name,_that.type);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String name,  int type)  $default,) {final _that = this;
+switch (_that) {
+case _Question():
+return $default(_that.name,_that.type);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String name,  int type)?  $default,) {final _that = this;
+switch (_that) {
+case _Question() when $default != null:
+return $default(_that.name,_that.type);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$_Question implements _Question {
-  const _$_Question(this.name, this.type);
 
-  factory _$_Question.fromJson(Map<String, dynamic> json) =>
-      _$$_QuestionFromJson(json);
+class _Question implements Question {
+  const _Question(this.name, this.type);
+  factory _Question.fromJson(Map<String, dynamic> json) => _$QuestionFromJson(json);
 
-  @override
-  final String name;
-  @override
-  final int type;
+@override final  String name;
+@override final  int type;
 
-  @override
-  String toString() {
-    return 'Question(name: $name, type: $type)';
-  }
+/// Create a copy of Question
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$QuestionCopyWith<_Question> get copyWith => __$QuestionCopyWithImpl<_Question>(this, _$identity);
 
-  @override
-  bool operator ==(dynamic other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _Question &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.type, type) || other.type == type));
-  }
-
-  @override
-  int get hashCode => Object.hash(runtimeType, name, type);
-
-  @JsonKey(ignore: true)
-  @override
-  _$QuestionCopyWith<_Question> get copyWith =>
-      __$QuestionCopyWithImpl<_Question>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$_QuestionToJson(this);
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$QuestionToJson(this, );
 }
 
-abstract class _Question implements Question {
-  const factory _Question(String name, int type) = _$_Question;
-
-  factory _Question.fromJson(Map<String, dynamic> json) = _$_Question.fromJson;
-
-  @override
-  String get name;
-  @override
-  int get type;
-  @override
-  @JsonKey(ignore: true)
-  _$QuestionCopyWith<_Question> get copyWith =>
-      throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Question&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type));
 }
 
-Answer _$AnswerFromJson(Map<String, dynamic> json) {
-  return _Answer.fromJson(json);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,type);
+
+@override
+String toString() {
+  return 'Question(name: $name, type: $type)';
+}
+
+
 }
 
 /// @nodoc
-class _$AnswerTearOff {
-  const _$AnswerTearOff();
+abstract mixin class _$QuestionCopyWith<$Res> implements $QuestionCopyWith<$Res> {
+  factory _$QuestionCopyWith(_Question value, $Res Function(_Question) _then) = __$QuestionCopyWithImpl;
+@override @useResult
+$Res call({
+ String name, int type
+});
 
-  _Answer call(String name, int type, int TTL, String data) {
-    return _Answer(
-      name,
-      type,
-      TTL,
-      data,
-    );
-  }
 
-  Answer fromJson(Map<String, Object?> json) {
-    return Answer.fromJson(json);
-  }
+
+
+}
+/// @nodoc
+class __$QuestionCopyWithImpl<$Res>
+    implements _$QuestionCopyWith<$Res> {
+  __$QuestionCopyWithImpl(this._self, this._then);
+
+  final _Question _self;
+  final $Res Function(_Question) _then;
+
+/// Create a copy of Question
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? name = null,Object? type = null,}) {
+  return _then(_Question(
+null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
 }
 
-/// @nodoc
-const $Answer = _$AnswerTearOff();
+
+}
+
 
 /// @nodoc
 mixin _$Answer {
-  String get name => throw _privateConstructorUsedError;
-  int get type => throw _privateConstructorUsedError;
-  int get TTL => throw _privateConstructorUsedError;
-  String get data => throw _privateConstructorUsedError;
 
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $AnswerCopyWith<Answer> get copyWith => throw _privateConstructorUsedError;
+/// Name of the resource record
+ String get name;/// Numeric type code of the DNS record
+ int get type;/// Time to live (TTL) in seconds
+ int get TTL;/// Data contained in the record (IP, CNAME, TXT, etc.)
+ String get data;
+/// Create a copy of Answer
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AnswerCopyWith<Answer> get copyWith => _$AnswerCopyWithImpl<Answer>(this as Answer, _$identity);
+
+  /// Serializes this Answer to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Answer&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.TTL, TTL) || other.TTL == TTL)&&(identical(other.data, data) || other.data == data));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,type,TTL,data);
+
+@override
+String toString() {
+  return 'Answer(name: $name, type: $type, TTL: $TTL, data: $data)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $AnswerCopyWith<$Res> {
-  factory $AnswerCopyWith(Answer value, $Res Function(Answer) then) =
-      _$AnswerCopyWithImpl<$Res>;
-  $Res call({String name, int type, int TTL, String data});
+abstract mixin class $AnswerCopyWith<$Res>  {
+  factory $AnswerCopyWith(Answer value, $Res Function(Answer) _then) = _$AnswerCopyWithImpl;
+@useResult
+$Res call({
+ String name, int type, int TTL, String data
+});
+
+
+
+
 }
-
 /// @nodoc
-class _$AnswerCopyWithImpl<$Res> implements $AnswerCopyWith<$Res> {
-  _$AnswerCopyWithImpl(this._value, this._then);
+class _$AnswerCopyWithImpl<$Res>
+    implements $AnswerCopyWith<$Res> {
+  _$AnswerCopyWithImpl(this._self, this._then);
 
-  final Answer _value;
-  // ignore: unused_field
+  final Answer _self;
   final $Res Function(Answer) _then;
 
-  @override
-  $Res call({
-    Object? name = freezed,
-    Object? type = freezed,
-    Object? TTL = freezed,
-    Object? data = freezed,
-  }) {
-    return _then(_value.copyWith(
-      name: name == freezed
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      type: type == freezed
-          ? _value.type
-          : type // ignore: cast_nullable_to_non_nullable
-              as int,
-      TTL: TTL == freezed
-          ? _value.TTL
-          : TTL // ignore: cast_nullable_to_non_nullable
-              as int,
-      data: data == freezed
-          ? _value.data
-          : data // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
+/// Create a copy of Answer
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? type = null,Object? TTL = null,Object? data = null,}) {
+  return _then(_self.copyWith(
+name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as int,TTL: null == TTL ? _self.TTL : TTL // ignore: cast_nullable_to_non_nullable
+as int,data: null == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
 }
 
-/// @nodoc
-abstract class _$AnswerCopyWith<$Res> implements $AnswerCopyWith<$Res> {
-  factory _$AnswerCopyWith(_Answer value, $Res Function(_Answer) then) =
-      __$AnswerCopyWithImpl<$Res>;
-  @override
-  $Res call({String name, int type, int TTL, String data});
 }
 
-/// @nodoc
-class __$AnswerCopyWithImpl<$Res> extends _$AnswerCopyWithImpl<$Res>
-    implements _$AnswerCopyWith<$Res> {
-  __$AnswerCopyWithImpl(_Answer _value, $Res Function(_Answer) _then)
-      : super(_value, (v) => _then(v as _Answer));
 
-  @override
-  _Answer get _value => super._value as _Answer;
+/// Adds pattern-matching-related methods to [Answer].
+extension AnswerPatterns on Answer {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @override
-  $Res call({
-    Object? name = freezed,
-    Object? type = freezed,
-    Object? TTL = freezed,
-    Object? data = freezed,
-  }) {
-    return _then(_Answer(
-      name == freezed
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      type == freezed
-          ? _value.type
-          : type // ignore: cast_nullable_to_non_nullable
-              as int,
-      TTL == freezed
-          ? _value.TTL
-          : TTL // ignore: cast_nullable_to_non_nullable
-              as int,
-      data == freezed
-          ? _value.data
-          : data // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Answer value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Answer() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Answer value)  $default,){
+final _that = this;
+switch (_that) {
+case _Answer():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Answer value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Answer() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String name,  int type,  int TTL,  String data)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Answer() when $default != null:
+return $default(_that.name,_that.type,_that.TTL,_that.data);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String name,  int type,  int TTL,  String data)  $default,) {final _that = this;
+switch (_that) {
+case _Answer():
+return $default(_that.name,_that.type,_that.TTL,_that.data);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String name,  int type,  int TTL,  String data)?  $default,) {final _that = this;
+switch (_that) {
+case _Answer() when $default != null:
+return $default(_that.name,_that.type,_that.TTL,_that.data);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$_Answer implements _Answer {
-  const _$_Answer(this.name, this.type, this.TTL, this.data);
 
-  factory _$_Answer.fromJson(Map<String, dynamic> json) =>
-      _$$_AnswerFromJson(json);
+class _Answer implements Answer {
+  const _Answer(this.name, this.type, this.TTL, this.data);
+  factory _Answer.fromJson(Map<String, dynamic> json) => _$AnswerFromJson(json);
 
-  @override
-  final String name;
-  @override
-  final int type;
-  @override
-  final int TTL;
-  @override
-  final String data;
+/// Name of the resource record
+@override final  String name;
+/// Numeric type code of the DNS record
+@override final  int type;
+/// Time to live (TTL) in seconds
+@override final  int TTL;
+/// Data contained in the record (IP, CNAME, TXT, etc.)
+@override final  String data;
 
-  @override
-  String toString() {
-    return 'Answer(name: $name, type: $type, TTL: $TTL, data: $data)';
-  }
+/// Create a copy of Answer
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$AnswerCopyWith<_Answer> get copyWith => __$AnswerCopyWithImpl<_Answer>(this, _$identity);
 
-  @override
-  bool operator ==(dynamic other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _Answer &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.type, type) || other.type == type) &&
-            (identical(other.TTL, TTL) || other.TTL == TTL) &&
-            (identical(other.data, data) || other.data == data));
-  }
-
-  @override
-  int get hashCode => Object.hash(runtimeType, name, type, TTL, data);
-
-  @JsonKey(ignore: true)
-  @override
-  _$AnswerCopyWith<_Answer> get copyWith =>
-      __$AnswerCopyWithImpl<_Answer>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$_AnswerToJson(this);
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$AnswerToJson(this, );
 }
 
-abstract class _Answer implements Answer {
-  const factory _Answer(String name, int type, int TTL, String data) =
-      _$_Answer;
-
-  factory _Answer.fromJson(Map<String, dynamic> json) = _$_Answer.fromJson;
-
-  @override
-  String get name;
-  @override
-  int get type;
-  @override
-  int get TTL;
-  @override
-  String get data;
-  @override
-  @JsonKey(ignore: true)
-  _$AnswerCopyWith<_Answer> get copyWith => throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Answer&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.TTL, TTL) || other.TTL == TTL)&&(identical(other.data, data) || other.data == data));
 }
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,type,TTL,data);
+
+@override
+String toString() {
+  return 'Answer(name: $name, type: $type, TTL: $TTL, data: $data)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$AnswerCopyWith<$Res> implements $AnswerCopyWith<$Res> {
+  factory _$AnswerCopyWith(_Answer value, $Res Function(_Answer) _then) = __$AnswerCopyWithImpl;
+@override @useResult
+$Res call({
+ String name, int type, int TTL, String data
+});
+
+
+
+
+}
+/// @nodoc
+class __$AnswerCopyWithImpl<$Res>
+    implements _$AnswerCopyWith<$Res> {
+  __$AnswerCopyWithImpl(this._self, this._then);
+
+  final _Answer _self;
+  final $Res Function(_Answer) _then;
+
+/// Create a copy of Answer
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? name = null,Object? type = null,Object? TTL = null,Object? data = null,}) {
+  return _then(_Answer(
+null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as int,null == TTL ? _self.TTL : TTL // ignore: cast_nullable_to_non_nullable
+as int,null == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/src/dns_record.g.dart
+++ b/lib/src/dns_record.g.dart
@@ -6,21 +6,21 @@ part of 'dns_record.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_DnsRecord _$$_DnsRecordFromJson(Map<String, dynamic> json) => _$_DnsRecord(
-      json['Status'] as int,
-      json['TC'] as bool,
-      json['RD'] as bool,
-      json['RA'] as bool,
-      json['AD'] as bool,
-      json['CD'] as bool,
-      json['edns_client_subnet'] as String?,
-      (json['Answer'] as List<dynamic>?)
-          ?.map((e) => Answer.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      json['Comment'] as String?,
-    );
+_DnsRecord _$DnsRecordFromJson(Map<String, dynamic> json) => _DnsRecord(
+  status: (json['Status'] as num).toInt(),
+  TC: json['TC'] as bool,
+  RD: json['RD'] as bool,
+  RA: json['RA'] as bool,
+  AD: json['AD'] as bool,
+  CD: json['CD'] as bool,
+  ednsClientSubnet: json['edns_client_subnet'] as String?,
+  answer: (json['Answer'] as List<dynamic>?)
+      ?.map((e) => Answer.fromJson(e as Map<String, dynamic>))
+      .toList(),
+  comment: json['Comment'] as String?,
+);
 
-Map<String, dynamic> _$$_DnsRecordToJson(_$_DnsRecord instance) =>
+Map<String, dynamic> _$DnsRecordToJson(_DnsRecord instance) =>
     <String, dynamic>{
       'Status': instance.status,
       'TC': instance.TC,
@@ -33,27 +33,24 @@ Map<String, dynamic> _$$_DnsRecordToJson(_$_DnsRecord instance) =>
       'Comment': instance.comment,
     };
 
-_$_Question _$$_QuestionFromJson(Map<String, dynamic> json) => _$_Question(
-      json['name'] as String,
-      json['type'] as int,
-    );
+_Question _$QuestionFromJson(Map<String, dynamic> json) =>
+    _Question(json['name'] as String, (json['type'] as num).toInt());
 
-Map<String, dynamic> _$$_QuestionToJson(_$_Question instance) =>
-    <String, dynamic>{
-      'name': instance.name,
-      'type': instance.type,
-    };
+Map<String, dynamic> _$QuestionToJson(_Question instance) => <String, dynamic>{
+  'name': instance.name,
+  'type': instance.type,
+};
 
-_$_Answer _$$_AnswerFromJson(Map<String, dynamic> json) => _$_Answer(
-      json['name'] as String,
-      json['type'] as int,
-      json['TTL'] as int,
-      json['data'] as String,
-    );
+_Answer _$AnswerFromJson(Map<String, dynamic> json) => _Answer(
+  json['name'] as String,
+  (json['type'] as num).toInt(),
+  (json['TTL'] as num).toInt(),
+  json['data'] as String,
+);
 
-Map<String, dynamic> _$$_AnswerToJson(_$_Answer instance) => <String, dynamic>{
-      'name': instance.name,
-      'type': instance.type,
-      'TTL': instance.TTL,
-      'data': instance.data,
-    };
+Map<String, dynamic> _$AnswerToJson(_Answer instance) => <String, dynamic>{
+  'name': instance.name,
+  'type': instance.type,
+  'TTL': instance.TTL,
+  'data': instance.data,
+};

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,19 +1,19 @@
 name: dns_client
-description: Dart implementation of DNS-over-HTTPS.
-version: 0.2.1
+description: Dart implementation of DNS-over-HTTPS client.
+version: 1.0.0
 homepage: https://github.com/dietfriends/dns_client
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  http: ^0.13.1
-  freezed_annotation: ^1.0.0
-  json_annotation: ^4.3.0
+  http: ^1.6.0
+  freezed_annotation: ^3.1.0
+  json_annotation: ^4.9.0
 
 dev_dependencies:
-  pedantic: ^1.11.0
-  test: ^1.6.0
-  json_serializable: ^6.0.1
-  build_runner: ^2.1.5
-  freezed: ^1.0.0
+  lints: ^5.1.1
+  test: ^1.28.0
+  json_serializable: ^6.11.3
+  build_runner: ^2.10.4
+  freezed: ^3.2.4

--- a/test/dns_client_test.dart
+++ b/test/dns_client_test.dart
@@ -1,36 +1,101 @@
 import 'package:dns_client/dns_client.dart';
-import 'package:dns_client/src/dns_over_https.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('HttpDnsClient Google', () {
-    test('lookup( google.com )', () async {
-      final client = DnsOverHttps.google();
-      final address = await client.lookup('google.com');
-      expect(address, isNotNull);
-      expect(address.isNotEmpty, isTrue);
+  group('DnsOverHttps - Google', () {
+    late DnsOverHttps client;
+
+    setUp(() {
+      client = DnsOverHttps.google();
+    });
+
+    tearDown(() {
+      client.close(force: true);
+    });
+
+    test('lookup IPv4/IPv6 for google.com', () async {
+      final addresses = await client.lookup('google.com');
+      expect(addresses, isNotNull);
+      expect(addresses, isNotEmpty);
+
+      for (var addr in addresses) {
+        print(addr);
+        expect(addr.address, isNotEmpty);
+        expect(
+          addr.address,
+          matches(RegExp(r'^(\d{1,3}\.){3}\d{1,3}$|^[\da-f:]+$')),
+        );
+      }
     });
   });
 
-  group('HttpDnsClient Cloudflare', () {
-    test('lookup( google.com )', () async {
-      final client = DnsOverHttps.cloudflare();
-      final address = await client.lookup('google.com');
-      expect(address, isNotNull);
-      expect(address.isNotEmpty, isTrue);
+  group('DnsOverHttps - Cloudflare', () {
+    late DnsOverHttps client;
+
+    setUp(() {
+      client = DnsOverHttps.cloudflare();
     });
 
-    test('cname test', () async {
-      final client = DnsOverHttps.cloudflare();
-      final address = await client.lookup('api.google.com');
-      expect(address, isNotNull);
-      expect(address.isNotEmpty, isTrue);
+    tearDown(() {
+      client.close(force: true);
     });
 
-    test('close', () async {
-      final client = DnsOverHttps.cloudflare();
-      client.close();
-      expect(client.lookup('api.google.com'), throwsA(isA<StateError>()));
+    test('lookup IPv4/IPv6 for google.com', () async {
+      final addresses = await client.lookup(
+        'google.com',
+        type: DnsRecordType.AAAA,
+      );
+      print(addresses);
+      expect(addresses, isNotNull);
+      expect(addresses, isNotEmpty);
+    });
+
+    test('lookup CNAME for api.google.com', () async {
+      final record = await client.lookupRecord(
+        'api.google.com',
+        type: DnsRecordType.CNAME,
+      );
+
+      print(record);
+
+      expect(record, isNotNull);
+      expect(record.answer, isNotEmpty);
+
+      final cnameAnswers = record.answer!.where(
+        (r) => r.recordType == DnsRecordType.CNAME,
+      ); // CNAME = 5
+      expect(cnameAnswers, isNotEmpty);
+      for (var answer in cnameAnswers) {
+        expect(answer.data, isNotEmpty);
+        expect(answer.data, contains('.'));
+      }
+    });
+
+    test('lookup MX for gmail.com', () async {
+      final record = await client.lookupRecord(
+        'gmail.com',
+        type: DnsRecordType.MX,
+      );
+
+      print(record);
+
+      expect(record, isNotNull);
+      expect(record.answer, isNotEmpty);
+
+      final mxAnswers = record.answer!.where(
+        (r) => r.recordType == DnsRecordType.MX,
+      ); // MX = 15
+      expect(mxAnswers, isNotEmpty);
+
+      for (var answer in mxAnswers) {
+        expect(answer.data, contains('.'));
+        expect(answer.name, contains('gmail.com'));
+      }
+    });
+
+    test('close client prevents further lookups', () async {
+      client.close(force: true);
+      expect(() => client.lookup('api.google.com'), throwsA(isA<StateError>()));
     });
   });
 }


### PR DESCRIPTION
- Updated `DnsClient` interface:
    - `lookup` method now supports optional `DnsRecordType` parameter to filter results.
    - Added `lookupRecord` method to fetch full DNS records with specified type.
    - Added `close` method with `force` parameter to control client shutdown behavior.

- `DnsOverHttps` implementation:
    - Refactored `lookup` to support filtering by DNS record type.
    - Added `lookupRecord` method to perform DNS-over-HTTPS queries returning full `DnsRecord`.
    - Improved HTTP client initialization and request construction.
    - Added `close` method override with `force` option.

- `dns_record.dart`:
    - Migrated to freezed v3 with named parameters, required fields, and improved JSON handling. - Redesigned `DnsRecord`, `Question`, and `Answer` classes with detailed fields and JSON serialization.
    - Added `DnsRecordType` enum with common DNS record types and utilities.
    - Added extension on `Answer` to get typed DNS record type.
    - Improved JSON serialization/deserialization with null safety and type conversions.

- Example usage updated:
    - Demonstrates querying different DNS record types (A, MX).
    - Uses enhanced `lookup` and `lookupRecord` methods.

- Tests:
    - Added comprehensive tests for Google and Cloudflare DoH clients.
    - Tests cover lookup of A, AAAA, CNAME, MX records.
    - Added test for client close behavior preventing further lookups.

- Dependency updates:
    - Dart SDK constraint updated to `>=3.8.0 <4.0.0`.
    - Updated dependencies:
        - `http` ^1.6.0
        - `freezed_annotation` ^3.1.0 - `json_annotation` ^4.9.0
    - Updated dev_dependencies: - `lints` ^5.1.1 - `test` ^1.28.0 - `json_serializable` ^6.11.3 - `build_runner` ^2.10.4 - `freezed` ^3.2.4

- Analysis options:
    - Replaced `pedantic` with `lints/recommended.yaml`.
    - Added ignore for `invalid_annotation_target` error.