### PR TITLE
feat: add OpenDNS provider support (wire format)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,6 +14,7 @@ This document outlines planned DNS-over-HTTPS (DoH) providers to be added to the
 ### Wire Format (DnsOverHttpsWire)
 
 - **Quad9** - `DnsOverHttpsWire.quad9()`, `quad9Ecs()`, `quad9Unsecured()`
+- **OpenDNS** - `DnsOverHttpsWire.opendns()`, `opendnsFamilyShield()`
 
 ## Planned Providers
 
@@ -22,16 +23,16 @@ This document outlines planned DNS-over-HTTPS (DoH) providers to be added to the
 | Provider      | Endpoint                                           | Variants                | Notes                            | Status |
 | ------------- | -------------------------------------------------- | ----------------------- | -------------------------------- | ------ |
 | NextDNS       | `https://dns.nextdns.io/dns-query`                 | Anycast                 | Privacy-focused, browser default | Done   |
-| OpenDNS       | `https://doh.opendns.com/dns-query`                | FamilyShield            | Cisco-owned, enterprise-grade    |        |
 | CleanBrowsing | `https://doh.cleanbrowsing.org/doh/family-filter/` | Family, Adult, Security | Content filtering                |        |
 | DNS.SB        | `https://doh.dns.sb/dns-query`                     | -                       | Privacy-focused, no logging      |        |
 
 ### Phase 2: Wire Format Providers
 
-| Provider | Endpoint                            | Variants          | Notes                         |
-| -------- | ----------------------------------- | ----------------- | ----------------------------- |
-| Mullvad  | `https://dns.mullvad.net/dns-query` | adblock, extended | VPN provider, strong privacy  |
-| ControlD | `https://freedns.controld.com/p0`   | p0, p1, p2        | Configurable filtering levels |
+| Provider | Endpoint                            | Variants          | Notes                         | Status |
+| -------- | ----------------------------------- | ----------------- | ----------------------------- | ------ |
+| OpenDNS  | `https://doh.opendns.com/dns-query` | FamilyShield      | Cisco-owned, enterprise-grade | Done   |
+| Mullvad  | `https://dns.mullvad.net/dns-query` | adblock, extended | VPN provider, strong privacy  |        |
+| ControlD | `https://freedns.controld.com/p0`   | p0, p1, p2        | Configurable filtering levels |        |
 
 ## Implementation Notes
 

--- a/lib/src/dns_over_https_wire.dart
+++ b/lib/src/dns_over_https_wire.dart
@@ -106,6 +106,33 @@ class DnsOverHttpsWire extends DnsClient {
     );
   }
 
+  // ========== OpenDNS Factory Constructors ==========
+
+  /// OpenDNS standard DNS-over-HTTPS.
+  ///
+  /// Enterprise-grade DNS service owned by Cisco.
+  ///
+  /// [OpenDNS documentation](https://support.opendns.com/hc/en-us/articles/360038086532)
+  factory DnsOverHttpsWire.opendns({Duration? timeout}) {
+    return DnsOverHttpsWire(
+      'https://doh.opendns.com/dns-query',
+      timeout: timeout,
+    );
+  }
+
+  /// OpenDNS FamilyShield with automatic adult content blocking.
+  ///
+  /// Pre-configured to block adult content - no account required.
+  /// Ideal for family networks and parental controls.
+  ///
+  /// [OpenDNS FamilyShield documentation](https://www.opendns.com/setupguide/#familyshield)
+  factory DnsOverHttpsWire.opendnsFamilyShield({Duration? timeout}) {
+    return DnsOverHttpsWire(
+      'https://doh.familyshield.opendns.com/dns-query',
+      timeout: timeout,
+    );
+  }
+
   // ========== DnsClient Interface Implementation ==========
 
   @override

--- a/specs/001-adguard-dns/spec.md
+++ b/specs/001-adguard-dns/spec.md
@@ -1,0 +1,79 @@
+# Specification: Add AdGuard DNS Provider Support
+
+## Overview
+
+Add AdGuard DNS as a new DNS-over-HTTPS (DoH) provider to the dns_client package.
+
+## Problem Statement
+
+Currently, the package only supports Google DNS and Cloudflare DNS.
+Users who want to use AdGuard DNS for its ad-blocking and privacy features
+must manually configure the URL.
+
+## Solution
+
+Add factory constructors for AdGuard DNS variants following the existing pattern.
+
+## Functional Requirements
+
+### FR-1: AdGuard DNS Default
+
+- Factory: `DnsOverHttps.adguard({Duration? timeout})`
+- Endpoint: `https://dns.adguard-dns.com/resolve`
+- Behavior: Blocks ads and trackers
+
+### FR-2: AdGuard DNS Non-filtering
+
+- Factory: `DnsOverHttps.adguardNonFiltering({Duration? timeout})`
+- Endpoint: `https://unfiltered.adguard-dns.com/resolve`
+- Behavior: No filtering, pure DNS resolution
+
+### FR-3: AdGuard DNS Family
+
+- Factory: `DnsOverHttps.adguardFamily({Duration? timeout})`
+- Endpoint: `https://family.adguard-dns.com/resolve`
+- Behavior: Blocks adult content in addition to ads
+
+## Non-Functional Requirements
+
+### NFR-1: API Compatibility
+
+All existing `DnsClient` methods must work with AdGuard DNS:
+
+- `lookup(hostname)` - IPv4 lookup
+- `lookupDataByRRType(hostname, rrType)` - Any record type lookup
+
+### NFR-2: Performance
+
+Response times should be comparable to existing providers.
+
+### NFR-3: Privacy
+
+The `maximalPrivacy` option should work (though AdGuard may not fully support `edns_client_subnet`).
+
+## Technical Notes
+
+### JSON API Format
+
+AdGuard DNS supports Google-compatible JSON format via `/resolve` endpoint:
+
+- Request: `https://dns.adguard-dns.com/resolve?name=example.com&type=A`
+- Response: JSON with `Status`, `Question`, `Answer` fields
+
+### Known Limitations
+
+- AdGuard DNS does not return `edns_client_subnet` in JSON responses
+- Uses `/resolve` endpoint (not `/dns-query`)
+
+## Out of Scope
+
+- DNS-over-TLS (DoT) support
+- DNS-over-QUIC (DoQ) support
+- Wire format (RFC 8484 binary) support
+
+## Success Criteria
+
+1. All three factory constructors work correctly
+2. Tests pass for basic lookups
+3. README documentation updated
+4. No breaking changes to existing API

--- a/specs/002-wire-format-quad9/spec.md
+++ b/specs/002-wire-format-quad9/spec.md
@@ -1,0 +1,131 @@
+# Spec 002: DNS Wire Format Support + Quad9 Provider
+
+## Summary
+
+Add DNS wire format (RFC 1035/8484) support to the dns_client package to enable providers
+that don't support JSON format, starting with Quad9.
+
+## Problem Statement
+
+The current dns_client package only supports JSON-based DoH (DNS-over-HTTPS) using the
+`application/dns-json` content type. This limits the package to providers that offer
+JSON APIs (Google, Cloudflare, AdGuard).
+
+Several major DNS providers only support the standard DNS wire format:
+
+- **Quad9** - Retired JSON service on May 5, 2025
+- **OpenDNS** - No JSON support
+- **CleanBrowsing** - No JSON support
+
+## Goals
+
+1. Add DNS wire format encoder/decoder (RFC 1035)
+2. Add DoH wire format support (RFC 8484)
+3. Add Quad9 DNS provider with 3 variants
+4. Maintain 100% backward compatibility with existing JSON API
+5. Support HTTP/2 (required by Quad9)
+
+## Non-Goals
+
+- UDP/TCP DNS transport (out of scope)
+- AXFR zone transfers
+- DNSSEC validation logic
+- DNS message signing
+
+## Technical Requirements
+
+### Wire Format Components
+
+1. **DNS Message Encoder** - Create binary DNS query messages
+   - 12-byte header (ID, flags, counts)
+   - Question section with QNAME encoding (label-length format)
+   - Support for all existing RRType values
+
+2. **DNS Message Decoder** - Parse binary DNS response messages
+   - Header parsing (extract status, flags, counts)
+   - Question section parsing
+   - Answer/Authority/Additional section parsing
+   - DNS name compression support (pointer handling)
+   - RDATA parsing for common types (A, AAAA, CNAME, MX, TXT, SRV, etc.)
+
+3. **DoH Transport**
+   - Support both GET (base64url encoded) and POST (binary body) methods
+   - Content-Type: `application/dns-message`
+   - Accept: `application/dns-message`
+
+### Quad9 Provider
+
+| Variant            | Endpoint                            | Features                  |
+| ------------------ | ----------------------------------- | ------------------------- |
+| `quad9()`          | `https://dns.quad9.net/dns-query`   | Malware blocking + DNSSEC |
+| `quad9Ecs()`       | `https://dns11.quad9.net/dns-query` | + EDNS Client Subnet      |
+| `quad9Unsecured()` | `https://dns10.quad9.net/dns-query` | No blocking, no DNSSEC    |
+
+### API Design
+
+```dart
+// Option A: Separate class for wire format
+class DnsOverHttpsWire extends DnsClient {
+  factory DnsOverHttpsWire.quad9({Duration? timeout});
+  factory DnsOverHttpsWire.quad9Ecs({Duration? timeout});
+  factory DnsOverHttpsWire.quad9Unsecured({Duration? timeout});
+}
+
+// Option B: Add to existing class with format parameter
+class DnsOverHttps extends DnsClient {
+  DnsOverHttps(this.url, {this.format = DnsFormat.json, ...});
+
+  factory DnsOverHttps.quad9({Duration? timeout}) =>
+    DnsOverHttps('https://dns.quad9.net/dns-query', format: DnsFormat.wire);
+}
+
+// Option C: Internal format detection based on provider
+// JSON providers: dns.google, cloudflare-dns.com, dns.adguard-dns.com
+// Wire providers: dns.quad9.net, doh.opendns.com
+```
+
+## Test Requirements
+
+1. Unit tests for wire format encoder/decoder
+2. Integration tests for Quad9 provider (all 3 variants)
+3. Round-trip tests (encode → send → decode → verify)
+4. Name compression handling tests
+
+## Dependencies
+
+- No new package dependencies
+- Uses `dart:typed_data` (ByteData, Uint8List)
+- Uses existing `dart:io` HttpClient
+
+## Risks & Mitigations
+
+| Risk                   | Mitigation                                       |
+| ---------------------- | ------------------------------------------------ |
+| HTTP/2 requirement     | Dart's HttpClient supports HTTP/2 by default     |
+| Wire format complexity | Well-documented RFC, comprehensive test coverage |
+| Breaking changes       | New classes/methods only, existing API unchanged |
+
+## Success Criteria
+
+- [ ] Wire format encoder/decoder passes unit tests
+- [ ] Quad9 lookups return correct DNS records
+- [ ] All existing tests continue to pass
+- [ ] No breaking changes to public API
+- [ ] Documentation updated with Quad9 examples
+
+## Decisions
+
+1. **API Design**: Option A - Separate `DnsOverHttpsWire` class
+   - Clean separation of concerns
+   - No changes to existing `DnsOverHttps` class
+   - Explicit wire format usage
+
+2. **HTTP Method**: POST as default
+   - Simpler implementation (no base64url encoding)
+   - More efficient (smaller request size)
+   - Quad9/Cloudflare both support POST
+
+3. **Error Handling**: Extend existing exceptions
+   - `DnsLookupException` for DNS-level errors (reuse)
+   - `DnsHttpException` for HTTP errors (reuse)
+   - Add `DnsWireFormatException` for parsing errors (new)

--- a/specs/004-opendns-provider/spec.md
+++ b/specs/004-opendns-provider/spec.md
@@ -1,0 +1,74 @@
+# Specification: Add OpenDNS Provider Support
+
+## Overview
+
+Add OpenDNS as a DNS-over-HTTPS (DoH) provider using wire format (RFC 8484).
+
+## Problem Statement
+
+OpenDNS (Cisco-owned) is a widely-used enterprise-grade DNS service.
+Users who want OpenDNS's reliability and FamilyShield filtering
+must manually configure the endpoint URL.
+
+## Solution
+
+Add factory constructors for OpenDNS variants to `DnsOverHttpsWire` class.
+
+## Functional Requirements
+
+### FR-1: OpenDNS Standard
+
+- Factory: `DnsOverHttpsWire.opendns({Duration? timeout})`
+- Endpoint: `https://doh.opendns.com/dns-query`
+- Behavior: Standard DNS resolution
+
+### FR-2: OpenDNS FamilyShield
+
+- Factory: `DnsOverHttpsWire.opendnsFamilyShield({Duration? timeout})`
+- Endpoint: `https://doh.familyshield.opendns.com/dns-query`
+- Behavior: Blocks adult content automatically
+
+## Non-Functional Requirements
+
+### NFR-1: API Compatibility
+
+All existing `DnsClient` methods must work with OpenDNS:
+
+- `lookup(hostname)` - IPv4 lookup
+- `lookupDataByRRType(hostname, rrType)` - Any record type lookup
+
+### NFR-2: Protocol Requirement
+
+OpenDNS only supports wire format (RFC 8484), NOT JSON format.
+Must use `DnsOverHttpsWire` class with HTTP/2.
+
+### NFR-3: Performance
+
+Response times should be comparable to existing wire format providers (Quad9).
+
+## Technical Notes
+
+### Wire Format Requirement
+
+OpenDNS follows RFC 8484 and accepts DoH using both GET and POST methods
+containing queries in DNS Wire Format. JSON format is NOT supported.
+
+### Known Endpoints
+
+| Variant      | Endpoint                                         | Features               |
+| ------------ | ------------------------------------------------ | ---------------------- |
+| Standard     | `https://doh.opendns.com/dns-query`              | Enterprise-grade DNS   |
+| FamilyShield | `https://doh.familyshield.opendns.com/dns-query` | Adult content blocking |
+
+## Out of Scope
+
+- DNS-over-TLS (DoT) support
+- JSON format support (not available)
+- Custom filtering configurations
+
+## Success Criteria
+
+1. Both factory constructors work correctly
+2. Tests pass for basic lookups
+3. ROADMAP.md updated (move to wire format section)
+4. No breaking changes to existing API

--- a/test/dns_over_https_wire_test.dart
+++ b/test/dns_over_https_wire_test.dart
@@ -85,6 +85,47 @@ void main() {
       });
     });
 
+    group('OpenDNS', () {
+      late DnsOverHttpsWire client;
+
+      setUp(() {
+        client = DnsOverHttpsWire.opendns();
+      });
+
+      tearDown(() {
+        client.close();
+      });
+
+      test('lookup returns IP addresses', () async {
+        final addresses = await client.lookup('google.com');
+        expect(addresses, isNotEmpty);
+        expect(addresses.first.address, isNotEmpty);
+      });
+
+      test('lookupWire returns DnsRecord', () async {
+        final record = await client.lookupWire('example.com', RRType.A);
+        expect(record.isSuccess, isTrue);
+        expect(record.answer, isNotNull);
+      });
+    });
+
+    group('OpenDNS FamilyShield', () {
+      late DnsOverHttpsWire client;
+
+      setUp(() {
+        client = DnsOverHttpsWire.opendnsFamilyShield();
+      });
+
+      tearDown(() {
+        client.close();
+      });
+
+      test('lookup returns IP addresses', () async {
+        final addresses = await client.lookup('google.com');
+        expect(addresses, isNotEmpty);
+      });
+    });
+
     group('client lifecycle', () {
       test('close prevents further lookups', () async {
         final client = DnsOverHttpsWire.quad9();


### PR DESCRIPTION
## Summary

Add OpenDNS as a DNS-over-HTTPS provider using wire format (RFC 8484).

## Changes

- Add `DnsOverHttpsWire.opendns()` factory constructor for standard OpenDNS
- Add `DnsOverHttpsWire.opendnsFamilyShield()` factory constructor for FamilyShield (adult content blocking)
- Add integration tests for both variants
- Update ROADMAP.md - move OpenDNS to wire format section and mark as Done
- Add specification document at `specs/004-opendns-provider/spec.md`

## Technical Notes

OpenDNS only supports wire format (RFC 8484), not JSON format. This is why it uses `DnsOverHttpsWire` class instead of `DnsOverHttps`.

## Endpoints

| Variant | Endpoint |
|---------|----------|
| Standard | `https://doh.opendns.com/dns-query` |
| FamilyShield | `https://doh.familyshield.opendns.com/dns-query` |

## Test Plan

- [x] `dart analyze` passes
- [x] All 55 tests pass
- [x] OpenDNS lookup test passes
- [x] OpenDNS FamilyShield lookup test passes

Closes #29